### PR TITLE
Fix for the migration

### DIFF
--- a/plugins/dependencies/src/main/kotlin/de/fayard/refreshVersions/RefreshVersionsMigrateTask.kt
+++ b/plugins/dependencies/src/main/kotlin/de/fayard/refreshVersions/RefreshVersionsMigrateTask.kt
@@ -125,7 +125,7 @@ private const val versionChars = "[a-zA-Z0-9_.{}$-]"
 
 @Language("RegExp")
 private val mavenCoordinateRegex =
-    "(['\"]$mavenChars{3,}:$mavenChars{3,}:)(?:_|$versionChars{3,})([\"'])".toRegex()
+    "(['\"]$mavenChars{4,}:$mavenChars{2,}:)(?:_|$versionChars{3,})([\"'])".toRegex()
 
 internal fun findFilesWithDependencyNotations(fromDir: File): List<File> {
     require(fromDir.isDirectory) { "Expected a directory, got ${fromDir.absolutePath}" }

--- a/plugins/dependencies/src/test/kotlin/de/fayard/refreshVersions/MigrationTest.kt
+++ b/plugins/dependencies/src/test/kotlin/de/fayard/refreshVersions/MigrationTest.kt
@@ -35,6 +35,7 @@ class MigrationTest : StringSpec({
             implementation 'com.example:name:1.2.3.eap.1'
             implementation 'com.example:name:1.2.3.eap1'
             implementation 'com.example:name:1.2.3-native-mt'
+            implementation "androidx.compose.ui:ui:${'$'}compose_version"
         """.trimIndent().lines()
         val expected = """
             implementation("com.example:name:_")
@@ -53,6 +54,7 @@ class MigrationTest : StringSpec({
             implementation 'com.example:name:_'
             implementation 'com.example:name:_'
             implementation 'com.example:name:_'
+            implementation "androidx.compose.ui:ui:_"
         """.trimIndent().lines()
         input.size shouldBeExactly expected.size
         List(input.size) { input[it] to expected[it] }


### PR DESCRIPTION
Reported by @LouisCAD 

----


Hello! I just tried to migrate a project that I freshly created from Android Studio BumbleBee Canary 9, selecting "Empty Compose Activity", and there was 2 problems:

-    The implementation "androidx.compose.ui:ui:$compose_version" line stayed as is, even though it has a corresponding built-in dependency notation (AndroidX.compose.ui).
-    The implementation "androidx.compose.ui:ui-tooling-preview:$compose_version" line became implementation "androidx.compose.ui:ui-tooling-preview:_", so the dependency version was replaced by the placeholder, unlike the other. That one doesn't have a built-in dependency notation BTW.

