### PR TITLE
fix noop comparison

### DIFF
--- a/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/NewRefreshVersionsImpl.kt
+++ b/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/NewRefreshVersionsImpl.kt
@@ -124,7 +124,7 @@ internal suspend fun lookupVersionCandidates(
                     key = propertyName
                 )?.let { Version(it) } ?: emptyVersion
                 val lowestVersionInCatalog = versionsCatalogLibraries.mapNotNull {
-                    val matches = it.module.group == moduleId.group && it.module.name == it.module.name
+                    val matches = it.module.group == moduleId.group && it.module.name == moduleId.name
                     when {
                         matches -> it.versionConstraint.tryExtractingSimpleVersion()?.let { rawVersion ->
                             Version(rawVersion)


### PR DESCRIPTION
## What?

Fixes a noop comparison.

## Why?

Because it is unlikely that it was intended that way.

## How?

Do the right comparison

## Testing?

I did not as I'm not sure how the effect of the wrong comparison is,
other than that it searches the lowest version for all dependencies
with that group in the version catalog instead of exactly that dependency
coordinates. I verified by looking at the debugger.
