### PR TITLE
fix broken link in bug_report.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,7 @@ name: Bug report
 about: Create a report to help us improve
 ---
 
-- [ ] I have read the [guidelines for submitting issues](https://jmfayard.github.io/refreshVersions/contributing/submitting-issues/)
+- [ ] I have read the [guidelines for submitting issues](https://splitties.github.io/refreshVersions/contributing/submitting-issues/#bug-reports)
 ## 🐛 Describe the bug
 <!-- A clear and concise description of what the bug is. -->
 


### PR DESCRIPTION
Hello/bonjour,

## What?

update guidelines link

Tell us what these changes are doing.

## Why?

the guidelines link still points to old url, changing it to new one
