### PR TITLE
Add missing '$' before {{  secrets.GITHUB_TOKEN }} in refreshversions-bot.md doc

### DIFF
--- a/docs/refreshversions-bot.md
+++ b/docs/refreshversions-bot.md
@@ -46,7 +46,7 @@ jobs:
         with:
           branch: dependency-update
         env:
-          GITHUB_TOKEN: {{ '{{' }} secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: {{ '${{' }} secrets.GITHUB_TOKEN }}
       - id: step-3
         name: gradle refreshVersions
         uses: gradle/gradle-build-action@v2
@@ -70,7 +70,7 @@ jobs:
           pr_title: Upgrade gradle dependencies
           pr_body: '[refreshVersions](https://github.com/jmfayard/refreshVersions) has found those library updates!'
           pr_draft: true
-          github_token: {{ '{{' }} secrets.GITHUB_TOKEN }}
+          github_token: {{ '${{' }} secrets.GITHUB_TOKEN }}
 ```
 
 Commit and Push.


### PR DESCRIPTION


<!-- Thanks for taking the time to write this Pull Request ❤️ -->
<!-- Be sure to read the guidelines for the development process => https://splitties.github.io/refreshVersions/contributing/submitting-prs/dev-process/ -->

Hello/bonjour,

## What?

Fix yaml syntax error by adding '$' before "{{  secrets.GITHUB_TOKEN }}" in [RefreshVersionsBot doc](https://splitties.github.io/refreshVersions/refreshversions-bot/#yaml-workflow)

## Why?

because otherwise the execution of refresh versions workflow fails with an error message like this: 
```
The workflow is not valid. .github/workflows/refreshVersions.yml (Line: 33, Col: 25): A mapping was not expected .github/workflows/refreshVersions.yml (Line: 57, Col: 25): A mapping was not expected
```

## How?

Add '$' before "{{  secrets.GITHUB_TOKEN }}"
