### PR TITLE
Bugfix/version catalog writing

### DIFF
--- a/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/TomlSection.kt
+++ b/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/TomlSection.kt
@@ -6,13 +6,13 @@ internal sealed class TomlSection(open val name: String) {
 
     object Root: TomlSection("root")
     object Versions: TomlSection("versions")
-    object Plugins: TomlSection("plugins")
-    object Bundles: TomlSection("bundles")
     object Libraries: TomlSection("libraries")
+    object Bundles: TomlSection("bundles")
+    object Plugins: TomlSection("plugins")
     data class Custom(override val name: String) : TomlSection(name)
 
     companion object {
-        val orderedSections = listOf(Root, Bundles, Plugins, Versions, Libraries)
+        val orderedSections = listOf(Root, Versions, Libraries, Bundles, Plugins)
 
         fun from(name: String): TomlSection = orderedSections.firstOrNull { it.name == name } ?: Custom(name)
     }

--- a/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/VersionsCatalogUpdater.kt
+++ b/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/internal/VersionsCatalogUpdater.kt
@@ -40,6 +40,7 @@ internal class VersionsCatalogUpdater(
             Version -> {
                 linesForUpdates(line, findLineReferencing(line))
             }
+
             Libs, Plugin -> {
                 val updates = dependenciesUpdates.firstOrNull {
                     it.moduleId.name == line.name && it.moduleId.group == line.group
@@ -71,7 +72,7 @@ internal class VersionsCatalogUpdater(
         val isObject = initialLine.unparsedValue.endsWith("}")
 
         val commentPrefix = "##"
-        val availableSymbol = "⬆"
+        val availableSymbol = "^"
         val versionPrefix = when {
             isObject || initialLine.section == TomlSection.Versions -> """= """"
             else -> """:"""
@@ -86,14 +87,13 @@ internal class VersionsCatalogUpdater(
             yield(commentPrefix)
             yield(availableSymbol)
             yield(versionPrefix)
-        }.sumOf { it.length }.let {
-            it + 1 // Because the length of availableSymbol (⬆) is 1, but it takes the width of 2 chars in the IDE.
-        }.let {
-            val indexOfCurrentVersion = initialLine.text.indexOf(currentVersion)
-            val gap = indexOfCurrentVersion - it
-            leadingSpace = " ".repeat((gap - 1).coerceAtLeast(0))
-            trailingSpace = if (gap > 0 && versionPrefix.endsWith(' ').not()) " " else ""
-        }
+        }.sumOf { it.length }
+            .let {
+                val indexOfCurrentVersion = initialLine.text.indexOf(currentVersion)
+                val gap = indexOfCurrentVersion - it
+                leadingSpace = " ".repeat((gap - 1).coerceAtLeast(0))
+                trailingSpace = if (gap > 0 && versionPrefix.endsWith(' ').not()) " " else ""
+            }
         return availableUpdates.mapTo(mutableListOf(initialLine)) { versionCandidate: MavenVersion ->
             val version = versionCandidate.value
             TomlLine(


### PR DESCRIPTION
Hello/bonjour,

## What?

Resolves #705

* Changed the symbol used for available versions in the version catalog
* Changed the TOML sections order for the version catalog

## Why?

Fixes the issues with version alignment in the version catalog which was dependent on the font used in the IDE. The symbol used is now font-agnostic and is always the same size.

This PR also fixes the somewhat annoying issue where the sections of the version catalog were re-ordered. The order now follows what most people will expect and also what is described in the Gradle documentation (See [here](https://docs.gradle.org/current/userguide/platforms.html#sub::toml-dependencies-format)).

## How?

* Replaced the `⬆` symbol with the `^` character
* Set the TOML sections order to the following:
    * Root
    * `[versions]`
    * `[libraries]`
    * `[bundles]`
    * `[plugins]`

## Testing?

Published to mavenLocal and tested in a local project using refreshVersions
