### PR TITLE
Attempt to fix Gradle 9 compatibility #735

### DIFF
--- a/plugins/convention-plugins/src/main/kotlin/PropertyOrEnv.kt
+++ b/plugins/convention-plugins/src/main/kotlin/PropertyOrEnv.kt
@@ -6,6 +6,10 @@ internal fun Project.propertyOrEnv(key: String): String {
         ?: error("Didn't find any value for the key \"$key\" in Project properties or environment variables.")
 }
 
-internal fun Project.propertyOrEnvOrNull(key: String): String? {
-    return findProperty(key) as String? ?: System.getenv(key)
+internal fun Project.propertyOrEnvOrNull(
+    key: String,
+    nullIfEmpty: Boolean = true
+): String? {
+    return (findProperty(key) as String?)?.takeUnless { nullIfEmpty && it.isEmpty() }
+        ?: System.getenv(key)?.takeUnless { nullIfEmpty && it.isEmpty() }
 }

--- a/plugins/convention-plugins/src/main/kotlin/gradle-plugin.gradle.kts
+++ b/plugins/convention-plugins/src/main/kotlin/gradle-plugin.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 }
 
 signing {
+    isRequired = false
     useInMemoryPgpKeys(
         propertyOrEnvOrNull("GPG_key_id"),
         propertyOrEnvOrNull("GPG_private_key") ?: return@signing,

--- a/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/RefreshVersionsCoreSetup.kt
+++ b/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/RefreshVersionsCoreSetup.kt
@@ -15,7 +15,6 @@ import de.fayard.refreshVersions.core.internal.setupVersionPlaceholdersResolving
 import org.gradle.api.artifacts.ExternalDependency
 import org.gradle.api.file.RegularFile
 import org.gradle.api.initialization.Settings
-import org.gradle.api.internal.artifacts.dependencies.DefaultClientModule
 import org.gradle.kotlin.dsl.apply
 import org.gradle.tooling.UnsupportedVersionException
 import org.gradle.util.GradleVersion
@@ -212,7 +211,7 @@ private fun setupPluginsVersionsResolution(
                 val pluginVersion = requested.version ?: return@eachPlugin
                 UsedPluginsTracker.pluginHasNoEntryInVersionsFile(
                     settings = settings,
-                    dependency = pluginIdToDependency(pluginId, pluginVersion)
+                    dependency = pluginIdToDependency(settings, pluginId, pluginVersion)
                 )
                 return@eachPlugin
             }
@@ -248,5 +247,5 @@ internal fun pluginDependencyNotationToVersionKey(dependencyNotation: String): S
         else -> null
     }
 
-internal fun pluginIdToDependency(pluginId: String, version: String): ExternalDependency =
-    DefaultClientModule(pluginId, "$pluginId.gradle.plugin", version)
+internal fun pluginIdToDependency(settings: Settings, pluginId: String, version: String): ExternalDependency =
+    settings.gradle.rootProject.dependencies.create("$pluginId:$pluginId.gradle.plugin:$version") as ExternalDependency

--- a/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/RefreshVersionsCoreSetup.kt
+++ b/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/RefreshVersionsCoreSetup.kt
@@ -253,5 +253,5 @@ internal fun pluginIdToDependency(
     version: String
 ): ExternalDependency {
     val dependencyNotation = "$pluginId:$pluginId.gradle.plugin:$version"
-    return settings.gradle.rootProject.dependencies.create(dependencyNotation) as ExternalDependency
+    return settings.gradle.rootProject.buildscript.dependencies.create(dependencyNotation) as ExternalDependency
 }

--- a/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/RefreshVersionsCoreSetup.kt
+++ b/plugins/core/src/main/kotlin/de/fayard/refreshVersions/core/RefreshVersionsCoreSetup.kt
@@ -247,5 +247,11 @@ internal fun pluginDependencyNotationToVersionKey(dependencyNotation: String): S
         else -> null
     }
 
-internal fun pluginIdToDependency(settings: Settings, pluginId: String, version: String): ExternalDependency =
-    settings.gradle.rootProject.dependencies.create("$pluginId:$pluginId.gradle.plugin:$version") as ExternalDependency
+internal fun pluginIdToDependency(
+    settings: Settings,
+    pluginId: String,
+    version: String
+): ExternalDependency {
+    val dependencyNotation = "$pluginId:$pluginId.gradle.plugin:$version"
+    return settings.gradle.rootProject.dependencies.create(dependencyNotation) as ExternalDependency
+}


### PR DESCRIPTION
Hello/bonjour,

## What?

Resolves #735

Tell us what these changes are doing.

## Why?

The plugin does not work with Gradle 9.

## How?

Replaced the internal API usage DefaultClientModule with public API for creating a dependency object programmatically.

## Testing?

I did not, lets see what CI tells us :sweat_smile: 
